### PR TITLE
MariaDB-only session tuning runs against Postgres connections, crashes Site DB data source

### DIFF
--- a/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
+++ b/insights/insights/doctype/insights_data_source_v3/insights_data_source_v3.py
@@ -188,7 +188,7 @@ class InsightsDataSourcev3(InsightsDataSourceDocument, Document):
 
         print(f"Connected to {self.name} ({self.title})")
 
-        if self.database_type == "MariaDB":
+        if self.database_type == "MariaDB" and db.name == "mysql":
             db.raw_sql("SET SESSION time_zone='+00:00'")
             db.raw_sql("SET collation_connection = 'utf8mb4_unicode_ci'")
             MAX_STATEMENT_TIMEOUT = (


### PR DESCRIPTION
Fixes the Postgres crash in `_get_ibis_backend()` described in the linked issue - MariaDB-only session tuning was gated only on the stored `database_type` field, which the shipped `Site DB` fixture hardcodes to `MariaDB` regardless of the site's actual database.

Added a check against the live ibis backend's dialect (`db.name == "mysql"`) so the tuning only fires when actually connected to MySQL/MariaDB.

Closes #10